### PR TITLE
Bato.to Fix

### DIFF
--- a/src/BatoTo/BatoTo.ts
+++ b/src/BatoTo/BatoTo.ts
@@ -18,10 +18,10 @@ import { Parser } from './Parser'
 const BATOTO_DOMAIN = 'https://bato.to'
 
 export const BatoToInfo: SourceInfo = {
-    version: '2.0.1',
+    version: '2.0.2',
     name: 'Bato.To',
     description: 'Extension that pulls western comics from bato.to',
-    author: 'GameFuzzy',
+    author: 'GameFuzzy & NmN',
     authorWebsite: 'http://github.com/gamefuzzy',
     icon: 'icon.png',
     contentRating: ContentRating.ADULT,


### PR DESCRIPTION
Fixed views not parsing due to the order of items in the page not being consistent, re-did details parsing so the order of items does not affect parsing. Added artist field which may or may not be present in a page. 
Redid the way isHentai works where the source compares known hentai tags against the tags of the manga. 
Overall refactored large parseMangaDetails into different functions to reduce complexity
Added a new function to calculate the number of views of a manga (calculateViews used in parseMangaDetails)