### PR TITLE
MangaPill.com fix

### DIFF
--- a/src/MangaPill/MangaPill.ts
+++ b/src/MangaPill/MangaPill.ts
@@ -20,7 +20,7 @@ import { Parser } from './Parser'
 const MANGAPILL_DOMAIN = 'https://www.mangapill.com'
 
 export const MangaPillInfo: SourceInfo = {
-    version: '2.0.9',
+    version: '2.1.0',
     name: 'MangaPill',
     description: 'Extension that pulls manga from mangapill.com. It has a lot of officially translated manga but can sometimes miss manga notifications',
     author: 'GameFuzzy',
@@ -53,7 +53,6 @@ export class MangaPill extends Source {
     }
 
     async getMangaDetails(mangaId: string): Promise<Manga> {
-
         const request = createRequestObject({
             url: `${MANGAPILL_DOMAIN}/manga/${mangaId}`,
             method: 'GET'
@@ -98,7 +97,6 @@ export class MangaPill extends Source {
     }
 
     override async filterUpdatedManga(mangaUpdatesFoundCallback: (updates: MangaUpdates) => void, time: Date, ids: string[]): Promise<void> {
-
         const request = createRequestObject({
             url: `${MANGAPILL_DOMAIN}/chapters`,
             method: 'GET'
@@ -124,7 +122,7 @@ export class MangaPill extends Source {
         const request = createRequestObject({
             url: `${MANGAPILL_DOMAIN}/search`,
             method: 'GET',
-            param: encodeURI(`?q=${query.title ?? ''}${tags}&page=${page}`)
+            param: `?q=${query.title ?? ''}${tags}&page=${page}`
         })
 
         const data = await this.requestManager.schedule(request, 1)
@@ -159,7 +157,6 @@ export class MangaPill extends Source {
 
 
     override async getHomePageSections(sectionCallback: (section: HomeSection) => void): Promise<void> {
-
         const sections = [
             {
                 request: createRequestObject({
@@ -212,7 +209,6 @@ export class MangaPill extends Source {
     }
 
     override async getViewMoreItems(_: string, metadata: any): Promise<PagedResults> {
-        
         if (!metadata) {
             const request = createRequestObject({
                 url: `${MANGAPILL_DOMAIN}/chapters`,
@@ -228,7 +224,7 @@ export class MangaPill extends Source {
             }
         }
 
-        const manga = metadata.slice(metadata.offset, metadata.offset + 20)
+        const manga = metadata.data.slice(metadata.offset, metadata.offset + 20)
 
         metadata.offset += 20
 

--- a/src/MangaPill/Parser.ts
+++ b/src/MangaPill/Parser.ts
@@ -14,7 +14,6 @@ const entities = require('entities')
 export class Parser {
 
     parseMangaDetails($: any, mangaId: string): Manga {
-
         const titles = [this.decodeHTMLEntity($('.font-bold.text-lg').text().trim())]
         const image = $('.lazy').attr('data-src')
         const summary = $('.text-sm.text--secondary').text().trim()
@@ -140,8 +139,6 @@ export class Parser {
         } else {
             return {updates: foundIds, loadNextPage: false}
         }
-
-
     }
 
     parseSearchResults($: any): MangaTile[] {
@@ -172,7 +169,8 @@ export class Parser {
 
         for (const obj of $('.grid.gap-1 input').toArray()) {
             const label = $(obj).parent().text().trim()
-            const id = encodeURIComponent('&genre=' + $(obj).attr('value') ?? label)
+
+            const id = ('&genre=' + $(obj).attr('value') ?? label).replace(/\s/g, '+')
             tagSections[0]!.tags = [...tagSections[0]?.tags ?? [], createTag({id, label})]
         }
 
@@ -182,20 +180,18 @@ export class Parser {
             // Capitalize first letter
             label = label.charAt(0).toUpperCase() + label.slice(1)
 
-            const id = encodeURIComponent('&type=' + $(obj).attr('value') ?? label)
+            const id = ('&type=' + $(obj).attr('value') ?? label)
             tagSections[1]!.tags = [...tagSections[1]?.tags ?? [], createTag({id, label})]
         }
 
         for (const obj of $('select#status option:not([value=""])').toArray()) {
-
             let label = $(obj).text().trim()
+
             // Capitalize first letter
             label = label.charAt(0).toUpperCase() + label.slice(1)
-
-            const id = encodeURIComponent('&status=' + $(obj).attr('value') ?? label)
+            const id = ('&status=' + $(obj).attr('value') ?? label).replace(/\s/g, '+')
             tagSections[2]!.tags = [...tagSections[2]?.tags ?? [], createTag({id, label})]
         }
-
         return tagSections
     }
 
@@ -247,7 +243,7 @@ export class Parser {
     isLastPage($: any): boolean {
         return $('a:contains("Next")').length < 1
     }
-    
+
     decodeHTMLEntity(str: string): string {
         return str.replace(/&#(\d+);/g, (_match, dec) => {
             return entities.decodeHTML(String.fromCharCode(dec))


### PR DESCRIPTION
Removed url encoding as the source doesn't seems to need it.
Fixed genres view not working due to the url path being incorrect (added a regex to remove all spaces with a + sign)
Fixed view more not working due to the metadata not being properly accessed.
Incremented version from 2.0.9 to 2.1.0