### PR TITLE
fix Bato.to chapter/volume numbering

### DIFF
--- a/src/BatoTo/BatoTo.ts
+++ b/src/BatoTo/BatoTo.ts
@@ -18,7 +18,7 @@ import { Parser } from './Parser'
 const BATOTO_DOMAIN = 'https://bato.to'
 
 export const BatoToInfo: SourceInfo = {
-    version: '2.0.2',
+    version: '2.0.3',
     name: 'Bato.To',
     description: 'Extension that pulls western comics from bato.to',
     author: 'GameFuzzy & NmN',

--- a/src/BatoTo/Parser.ts
+++ b/src/BatoTo/Parser.ts
@@ -85,16 +85,16 @@ export class Parser {
         const chapters: Chapter[] = []
 
         const theArray = $('.item', $('.main')).toArray().reverse()
-        theArray.forEach((obj: any, i: number) =>  {
+        theArray.forEach((obj: any) =>  {
             const chapterTile: any = $('a', $(obj))
             const chapterId = chapterTile.attr('href')?.replace('/chapter/', '')
             const chapGroup = $(chapterTile).text().trim().split('\n').pop()?.trim()
             const chapNamePart1 = $('b', chapterTile).text()
             let chapNamePart2 = $('span', $(chapterTile)).first().text().replace(':', '').trim()
             if (chapNamePart2 == chapGroup) chapNamePart2 = ''
-            const chapter = $('b', chapterTile).text()
-            const chapNum = i+1
-            const volume = Number(chapter?.split('chapter')[0]?.replace('volume', '').trim())
+            const chapter = $('b', chapterTile).text().toLowerCase().split(':')[0].split('chapter')
+            const chapNum = Number(chapter[1].trim())
+            const volume = Number(chapter[0].replace('volume', '').trim())
 
             const language = $('.emoji').attr('data-lang') ?? 'gb'
             const time = source.convertTime($('i.ps-3', $(obj)).text())


### PR DESCRIPTION
This PR fixes two chapter numbering issues for the BatoTo extension:

1. Volume numbers are not parsed due to a casing issue - the code expects a string like `"volume 2"` but it receives `"Volume 2").
2. Chapter numbers are not parsed correctly for manga that have point-chapters (e.g. [like this one](https://bato.to/series/73556/boku-no-kokoro-no-yabai-yatsu)). This is a problem for Trackers, which will update Anilist etc. with the incorrect chapter number.